### PR TITLE
add required key for number verification

### DIFF
--- a/lib/tenios/api/verification.rb
+++ b/lib/tenios/api/verification.rb
@@ -35,6 +35,7 @@ module Tenios
         document_type
         house_number
         street
+        zip
       ].freeze
       private_constant :OPTIONS
 

--- a/spec/tenios/api/verification_spec.rb
+++ b/spec/tenios/api/verification_spec.rb
@@ -18,7 +18,8 @@ module Tenios
             document_data: Base64.encode64('%PDF-1.3'),
             document_type: Verification::DOCUMENT_TYPES.sample,
             house_number: '10',
-            street: 'Downing Street'
+            street: 'Downing Street',
+            zip: 'W1'
           }
         end
         let(:options) { valid_options }


### PR DESCRIPTION
Just noticed their documentation is wrong. `zip` is required, but it's only listed in their example payload, not in the list of attributes :(