### PR TITLE
Implement POST /record-call/{start,stop}

### DIFF
--- a/lib/tenios/api/client.rb
+++ b/lib/tenios/api/client.rb
@@ -41,6 +41,7 @@ module Tenios
       endpoint :call_detail_records, :CallDetailRecords
       endpoint :verification, :Verification
       endpoint :number, :Number
+      endpoint :record_call, :RecordCall
     end
   end
 end

--- a/lib/tenios/api/record_call.rb
+++ b/lib/tenios/api/record_call.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Tenios
+  module API
+    class RecordCall
+      attr_reader :client
+
+      def initialize(client)
+        @client = client
+      end
+
+      def start(call_uuid:)
+        client.http_client.post(
+          '/record-call/start',
+          access_key: client.access_key,
+          call_uuid: call_uuid
+        ).body
+      end
+
+      def stop(recording_uuid:, call_uuid:)
+        client.http_client.post(
+          '/record-call/stop',
+          access_key: client.access_key,
+          call_uuid: call_uuid,
+          recording_uuid: recording_uuid
+        ).body
+      end
+    end
+  end
+end

--- a/spec/tenios/api/record_call_spec.rb
+++ b/spec/tenios/api/record_call_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Tenios
+  module API
+    RSpec.describe Client, '#record_call' do
+      subject(:record_call) { client.record_call }
+
+      let(:client) { described_class.new(access_key: 'test') }
+
+      describe '#start' do
+        subject(:start) { record_call.start(call_uuid: call_uuid) }
+
+        let(:call_uuid) { SecureRandom.uuid }
+        let(:response_body) { { 'recording_uuid' => SecureRandom.uuid } }
+        let(:response) { double(body: response_body) }
+        let(:expected_payload) do
+          [
+            '/record-call/start',
+            {
+              call_uuid: call_uuid,
+              access_key: 'test'
+            }
+          ]
+        end
+
+        before { allow(client.http_client).to receive(:post).and_return(response) }
+
+        it { expect(start).to eq response_body }
+
+        context 'HTTP requests' do
+          before { start }
+
+          it { expect(client.http_client).to have_received(:post).with(*expected_payload) }
+        end
+      end
+
+      describe '#stop' do
+        subject(:stop) { record_call.stop(call_uuid: call_uuid, recording_uuid: recording_uuid) }
+
+        let(:call_uuid) { SecureRandom.uuid }
+        let(:recording_uuid) { SecureRandom.uuid }
+        let(:response_body) { { 'success' => 'true' } }
+        let(:response) { double(body: response_body) }
+        let(:expected_payload) do
+          [
+            '/record-call/stop',
+            {
+              call_uuid: call_uuid,
+              recording_uuid: recording_uuid,
+              access_key: 'test'
+            }
+          ]
+        end
+
+        before { allow(client.http_client).to receive(:post).and_return(response) }
+
+        it { expect(stop).to eq response_body }
+
+        context 'HTTP requests' do
+          before { stop }
+
+          it { expect(client.http_client).to have_received(:post).with(*expected_payload) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the `record_call` endpoint to `Tenios::API::Client` with the
`start` and `stop` actions implemented.

[Tenios Docs](https://www.tenios.de/en/doc/api-call-recording)