### PR TITLE
Relax faraday version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 ### Security
 ### Misc
 
+## [1.0.4] - 2020-02-22
+
+### Fixed
+
+* Relax faraday version constraint
+
+[1.0.4]: https://github.com/carwow/tenios-api-ruby/compare/v1.0.3...v1.0.4
+
 ## [1.0.3] - 2020-02-16
 
 ### Misc

--- a/lib/tenios/api.rb
+++ b/lib/tenios/api.rb
@@ -4,6 +4,6 @@ require "tenios/api/client"
 
 module Tenios
   module API
-    autoload :Version, "tenios/api/version"
+    autoload :VERSION, "tenios/api/version"
   end
 end

--- a/lib/tenios/api/version.rb
+++ b/lib/tenios/api/version.rb
@@ -2,6 +2,6 @@
 
 module Tenios
   module API
-    VERSION = "1.0.3"
+    VERSION = "1.0.4"
   end
 end

--- a/tenios-api.gemspec
+++ b/tenios-api.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.start_with? "spec" }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 1.3"
+  spec.add_dependency "faraday", "~> 1.1"
   spec.add_dependency "faraday_middleware", "~> 1.0"
 
   spec.add_development_dependency "pry", "~> 0.14"


### PR DESCRIPTION
Required for compatibility with `json_api_client` gem in the same project.

Related: https://github.com/JsonApiClient/json_api_client/pull/377