### PR TITLE
Support Ruby 3.1 by relaxing version constraint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,4 +33,4 @@ workflows:
             parameters:
               ruby_version:
                 - "2.7"
-                - "3.0"
+                - "3.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 ### Security
 ### Misc
 
+## [1.0.5] - 2022-12-21
+
+### Changed
+
+* Relax ruby version constraint to support ruby 3.1
+* Relax faraday version constraint to major v1
+
+[1.0.5]: https://github.com/carwow/tenios-api-ruby/compare/v1.0.3...v1.0.4
+
 ## [1.0.4] - 2021-02-22
 
 ### Fixed

--- a/lib/tenios/api/version.rb
+++ b/lib/tenios/api/version.rb
@@ -2,6 +2,6 @@
 
 module Tenios
   module API
-    VERSION = "1.0.4"
+    VERSION = "1.0.5"
   end
 end

--- a/tenios-api.gemspec
+++ b/tenios-api.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/carwow/tenios-api-ruby"
   spec.license = "MIT"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7", "< 3.1")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["source_code_uri"] = spec.homepage
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.start_with? "spec" }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 1.1"
-  spec.add_dependency "faraday_middleware", "~> 1.0"
+  spec.add_dependency "faraday", "~> 1"
+  spec.add_dependency "faraday_middleware", "~> 1"
 
   spec.add_development_dependency "pry", "~> 0.14"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.10"
+  spec.add_development_dependency "rake", "~> 13"
+  spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "standard", "~> 0.12"
 end


### PR DESCRIPTION
Also, relax faraday constraint to major version as well.