### PR TITLE
[UA-61857] Add support for /transfer-call endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [Unreleased]
 
 ### Added
+
+* Support for `/transfer-call` API
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ client.record_call.stop(
 #### Transfer
 
 ```ruby
-client.transfer_call.transfer(
+client.transfer_call(
   call_uuid: '9315b018-86bd-424f-a086-7095ce427130',
   destination: '+441234567890'
 )

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ client.record_call.stop(
 )
 ```
 
+### Transfer Call
+
+[Tenios documentation](https://www.tenios.de/en/doc/transfer-call-api)
+
+#### Transfer
+
+```ruby
+client.transfer_call.transfer(
+  call_uuid: '9315b018-86bd-424f-a086-7095ce427130',
+  destination: '+441234567890'
+)
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/carwow/tenios-api-ruby.

--- a/lib/tenios/api/client.rb
+++ b/lib/tenios/api/client.rb
@@ -3,6 +3,7 @@
 require "json"
 require "faraday"
 require "faraday_middleware"
+require_relative "transfer_call"
 
 module Tenios
   module API
@@ -32,7 +33,11 @@ module Tenios
       endpoint :verification, :Verification
       endpoint :number, :Number
       endpoint :record_call, :RecordCall
-      endpoint :transfer_call, :TransferCall
+
+      def transfer_call(...)
+        @transfer_call ||= Tenios::API::TransferCall.new(self)
+        @transfer_call.transfer_call(...)
+      end
 
       # @api private
       def post(path, **payload)

--- a/lib/tenios/api/client.rb
+++ b/lib/tenios/api/client.rb
@@ -32,6 +32,7 @@ module Tenios
       endpoint :verification, :Verification
       endpoint :number, :Number
       endpoint :record_call, :RecordCall
+      endpoint :transfer_call, :TransferCall
 
       # @api private
       def post(path, **payload)

--- a/lib/tenios/api/transfer_call.rb
+++ b/lib/tenios/api/transfer_call.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Tenios
+  module API
+    class TransferCall
+      EXTERNAL_NUMBER = "EXTERNALNUMBER"
+      SIP_USER = "SIP_USER"
+      SIP_TRUNK = "SIP_TRUNK"
+
+      DESTINATION_TYPES = [
+        EXTERNAL_NUMBER,
+        SIP_USER,
+        SIP_TRUNK
+      ].freeze
+
+      attr_reader :client
+
+      def initialize(client)
+        @client = client
+      end
+
+      def transfer(call_uuid:, destination_type: EXTERNAL_NUMBER, destination:)
+        raise "destination_type must be one of #{DESTINATION_TYPES}" unless DESTINATION_TYPES.include?(destination_type)
+
+        client.post(
+          "/transfer-call",
+          call_uuid: call_uuid,
+          destination_type: destination_type,
+          destination: destination
+        )
+      end
+    end
+  end
+end

--- a/lib/tenios/api/transfer_call.rb
+++ b/lib/tenios/api/transfer_call.rb
@@ -19,7 +19,7 @@ module Tenios
         @client = client
       end
 
-      def transfer(call_uuid:, destination:, destination_type: EXTERNAL_NUMBER)
+      def transfer_call(call_uuid:, destination:, destination_type: EXTERNAL_NUMBER)
         raise "destination_type must be one of #{DESTINATION_TYPES}" unless DESTINATION_TYPES.include?(destination_type)
 
         client.post(

--- a/lib/tenios/api/transfer_call.rb
+++ b/lib/tenios/api/transfer_call.rb
@@ -19,7 +19,7 @@ module Tenios
         @client = client
       end
 
-      def transfer(call_uuid:, destination_type: EXTERNAL_NUMBER, destination:)
+      def transfer(call_uuid:, destination:, destination_type: EXTERNAL_NUMBER)
         raise "destination_type must be one of #{DESTINATION_TYPES}" unless DESTINATION_TYPES.include?(destination_type)
 
         client.post(

--- a/spec/tenios/api/client_spec.rb
+++ b/spec/tenios/api/client_spec.rb
@@ -21,10 +21,6 @@ module Tenios
         it { expect(client.record_call).to be_a(RecordCall) }
       end
 
-      describe "#transfer_call" do
-        it { expect(client.transfer_call).to be_a(TransferCall) }
-      end
-
       describe "#post" do
         let(:http_client) { instance_double(Faraday::Connection, post: response) }
         let(:response) { instance_double(Faraday::Response, body: "body") }

--- a/spec/tenios/api/client_spec.rb
+++ b/spec/tenios/api/client_spec.rb
@@ -21,6 +21,10 @@ module Tenios
         it { expect(client.record_call).to be_a(RecordCall) }
       end
 
+      describe "#transfer_call" do
+        it { expect(client.transfer_call).to be_a(TransferCall) }
+      end
+
       describe "#post" do
         let(:http_client) { instance_double(Faraday::Connection, post: response) }
         let(:response) { instance_double(Faraday::Response, body: "body") }

--- a/spec/tenios/api/transfer_call_spec.rb
+++ b/spec/tenios/api/transfer_call_spec.rb
@@ -13,7 +13,7 @@ module Tenios
         subject(:transfer) { transfer_call.transfer(call_uuid: call_uuid, destination: destination) }
 
         let(:call_uuid) { SecureRandom.uuid }
-        let(:destination) { '+441234567890' }
+        let(:destination) { "+441234567890" }
         let(:response) { {"success" => true} }
         let(:expected_payload) do
           [

--- a/spec/tenios/api/transfer_call_spec.rb
+++ b/spec/tenios/api/transfer_call_spec.rb
@@ -10,7 +10,7 @@ module Tenios
       let(:client) { described_class.new(access_key: "test") }
 
       describe "#transfer" do
-        subject(:start) { transfer_call.start(call_uuid: call_uuid, destination: destination) }
+        subject(:transfer) { transfer_call.transfer(call_uuid: call_uuid, destination: destination) }
 
         let(:call_uuid) { SecureRandom.uuid }
         let(:destination) { '+441234567890' }

--- a/spec/tenios/api/transfer_call_spec.rb
+++ b/spec/tenios/api/transfer_call_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Tenios
+  module API
+    RSpec.describe Client, "#transfer_call" do
+      subject(:transfer_call) { client.transfer_call }
+
+      let(:client) { described_class.new(access_key: "test") }
+
+      describe "#transfer" do
+        subject(:start) { transfer_call.start(call_uuid: call_uuid, destination: destination) }
+
+        let(:call_uuid) { SecureRandom.uuid }
+        let(:destination) { '+441234567890' }
+        let(:response) { {"success" => true} }
+        let(:expected_payload) do
+          [
+            "/transfer-call",
+            {
+              call_uuid: call_uuid,
+              destination_type: Tenios::API::TransferCall::EXTERNAL_NUMBER,
+              destination: destination
+            }
+          ]
+        end
+
+        before { allow(client).to receive(:post).and_return(response) }
+
+        it { expect(transfer).to eq response }
+
+        context "HTTP requests" do
+          before { transfer }
+
+          it { expect(client).to have_received(:post).with(*expected_payload) }
+        end
+      end
+    end
+  end
+end

--- a/spec/tenios/api/transfer_call_spec.rb
+++ b/spec/tenios/api/transfer_call_spec.rb
@@ -5,16 +5,18 @@ require "securerandom"
 module Tenios
   module API
     RSpec.describe Client, "#transfer_call" do
-      subject(:transfer_call) { client.transfer_call }
-
+      subject(:transfer_call) { client.transfer_call(call_uuid: call_uuid, destination: destination) }
       let(:client) { described_class.new(access_key: "test") }
+      let(:call_uuid) { SecureRandom.uuid }
+      let(:destination) { "+441234567890" }
+      let(:response) { {"success" => true} }
 
-      describe "#transfer" do
-        subject(:transfer) { transfer_call.transfer(call_uuid: call_uuid, destination: destination) }
+      before { allow(client).to receive(:post).and_return(response) }
 
-        let(:call_uuid) { SecureRandom.uuid }
-        let(:destination) { "+441234567890" }
-        let(:response) { {"success" => true} }
+      it { expect(transfer_call).to eq response }
+
+      context "HTTP requests" do
+        before { transfer_call }
         let(:expected_payload) do
           [
             "/transfer-call",
@@ -26,15 +28,7 @@ module Tenios
           ]
         end
 
-        before { allow(client).to receive(:post).and_return(response) }
-
-        it { expect(transfer).to eq response }
-
-        context "HTTP requests" do
-          before { transfer }
-
-          it { expect(client).to have_received(:post).with(*expected_payload) }
-        end
+        it { expect(client).to have_received(:post).with(*expected_payload) }
       end
     end
   end


### PR DESCRIPTION
https://carwow.kanbanize.com/ctrl_board/48/cards/61857/details/

https://www.tenios.de/en/doc/transfer-call-api

See card for details. In short, we need to add support for **transferring** calls from customer services to a dealership, rather than the current setup of **forwarding** the calls